### PR TITLE
Version bump for onnxruntime

### DIFF
--- a/v2functions/requirements.txt
+++ b/v2functions/requirements.txt
@@ -10,4 +10,4 @@ requests==2.20.1
 feedparser==5.2.1
 Pillow==7.0.0
 numpy==1.18.1
-onnxruntime==1.1.0
+onnxruntime==1.4.0


### PR DESCRIPTION
For some reason onnxruntime 1.5.1 (latest right now) produces a horrible exception, however 1.4.0 seems to work great. Keeping 1.4.0 for now.